### PR TITLE
Bugfixes for NLB/NLB Targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This is done by applying tags inside the AWS Account.
 session_mirror_blacklist (Interactive)
 ```
 
-2. Configure the VPCs should participate in Session Mirroring:
+2. Configure the VPCs which should participate in Session Mirroring:
 ```console
 session_mirror_config_vpc (Interactive)
 ```

--- a/aws_network_tap/config_vpc.py
+++ b/aws_network_tap/config_vpc.py
@@ -24,7 +24,7 @@ def find_mirror_target(region: str, vpc_id: str) -> Union[str, None]:
     """ return mirror target ARN """
     print("Choose a Mirror Target. Note: IP traffic must be routeable from the source ENI to the target.")
 
-    for target in Ec2ApiClient.list_mirror_targets(region=region): # type: Mirror_Target_Props
+    for target in Ec2ApiClient.list_mirror_targets(region=region):  # type: Mirror_Target_Props
         if target.vpc_bound and target.vpc_id != vpc_id:
             print(f'Warning: [{target.name}] is not recommended, unless transit gateway or vpc peering is in place.')
 
@@ -42,21 +42,26 @@ def find_mirror_target(region: str, vpc_id: str) -> Union[str, None]:
     return d_target_id
 
 
+def propmpt_vpc_config(vpc_prop: VPC_Props, region: str):
+    # if it currently has a certain tag, its tapped
+    current_tap_state = bool(vpc_prop.tags.get(Ec2ApiClient.TAG_KEY_VPC_TAP))
+    desc = 'enabled to ' + vpc_prop.tags.get(Ec2ApiClient.TAG_KEY_VPC_TAP) if current_tap_state else 'disabled'
+    change_config = 'y' in input(f'Modify default Session Mirroring Target for {vpc_prop.vpc_id}:{vpc_prop.name} (currently {desc})? (n) ').lower()
+    if not change_config:
+        return
+    if current_tap_state and 'y' in input(f"Disable Session Mirroring for this VPC? (n) ").lower():
+        mirror_target_arn = AWSTag.Delete
+    else:
+        mirror_target_arn = find_mirror_target(region=region, vpc_id=vpc_prop.vpc_id)
+    Ec2ApiClient.set_vpc_target(region=region, vpc_id=vpc_prop.vpc_id, session_mirror_target_arn=mirror_target_arn)
+    logging.info(f'VPC Session Mirroring Target updated to {mirror_target_arn}')
+
+
 def main() -> None:
     logging.getLogger().setLevel(logging.INFO)
     region = Ec2ApiClient.get_region()
     for vpc_prop in Ec2ApiClient.list_vpcs(region=region):  # type: VPC_Props
-        current_tap_state = bool(vpc_prop.tags.get(Ec2ApiClient.TAG_KEY_VPC_TAP))
-        desc = 'tapped' if current_tap_state else 'not tapped'
-        change_config = 'y' in input(f'Change VPC {vpc_prop.name} ({vpc_prop.vpc_id} is currently {desc})? (n) ').lower()
-        if not change_config:
-            continue
-        if current_tap_state:
-            mirror_target_arn = AWSTag.Delete
-        else:
-            mirror_target_arn = find_mirror_target(region=region, vpc_id=vpc_prop.vpc_id)
-        Ec2ApiClient.set_vpc_target(region=region, vpc_id=vpc_prop.vpc_id, session_mirror_target_arn=mirror_target_arn)
-        logging.info(f'VPC target updated to {mirror_target_arn}')
+        change_vpc_config(vpc_prop, region)
 
 
 if __name__ == '__main__':

--- a/aws_network_tap/models/ec2_api_client.py
+++ b/aws_network_tap/models/ec2_api_client.py
@@ -1,6 +1,7 @@
 
 
 from collections import namedtuple
+import logging
 from typing import Iterable, List, Union, Dict
 import boto3  # type: ignore
 from ec2_metadata import ec2_metadata  # type: ignore
@@ -85,20 +86,26 @@ class Ec2ApiClient:
         for target in response:
             tags = AWSTag.to_dict(target.get(AWSTag.TAGS_KEY))
             # get the VPC_ID
-
             if target['Type'] == cls.TARGET_NIC:
                 vpc_id = cls._get_client(region=region).describe_network_interfaces(NetworkInterfaceIds=[
                         target['NetworkInterfaceId'],
                 ])["NetworkInterfaces"][0]["VpcId"]
                 vpc_bound = True
             if target['Type'] == cls.TARGET_NLB:
-                lb = boto3.client('elbv2', region=region).describe_load_balancers(
-                    LoadBalancerArns=[
-                        target['NetworkLoadBalancerArn']
-                    ],
-                )['LoadBalancers'][0]
+                try:
+                    lb = boto3.client('elbv2', region_name=region).describe_load_balancers(
+                        LoadBalancerArns=[
+                            target['NetworkLoadBalancerArn']
+                        ],
+                    )['LoadBalancers'][0]
+                except Exception as e:
+                    if 'or more load balancers not found' in str(e):
+                        id = target['TrafficMirrorTargetId']
+                        logging.warning(f'Invalid Session Mirroring Target {id}, delete manually.')
+                        continue
+                    raise
                 vpc_id = lb["VpcId"]
-                vpc_bound = True if lb["Schema"] == "internal" else False
+                vpc_bound = True if lb.get("Schema") == "internal" else False
             yield Mirror_Target_Props(
                 target['TrafficMirrorTargetId'],
                 tags.get(AWSTag.NAME_KEY),

--- a/aws_network_tap/models/spile.py
+++ b/aws_network_tap/models/spile.py
@@ -76,10 +76,14 @@ class Spile:
                 ],
             )["TrafficMirrorSession"]
         except Exception as e:
-            if 'is in use by target' not in str(e):
-                raise
-            logging.warning(f'unable to tap {self.eni_tag.instance_id} due to existing tap')
-            return None
+            if 'is in use by target' in str(e):
+                logging.warning(f'unable to tap {self.eni_tag.instance_id} due to existing tap')
+                return None
+            if 'Sources per interface-target limit reached' in str(e):
+                logging.warning(f'unable to tap {self.eni_tag.instance_id} due to target limit')
+                return None
+            raise
+
         return MirrorSession(
             _["TrafficMirrorSessionId"],
             _["TrafficMirrorTargetId"],


### PR DESCRIPTION
Fixes some issues blocking customer enablement:
- Add a waiter for the created NLB to reach 'active' state
- Better messaging to the user of the asset names created, and less confusing abbreviations
- Handle cases where an Session Mirroring target exists but its ARN target no longer exists 
- Gracefully handle exceptions due to hitting the ENI target limit (default 10 sessions) 
- Make editing the VPC session target easier