### PR TITLE
gh-5 Support whitelist only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWS VPC Traffic Mirroring Session Manager
 
-This tool automates the creation and maintenance VPC Traffic Mirroring Sessions (Individual Network Taps) of Nitro based EC2 instances. 
+This tool automates the creation and maintenance of VPC Traffic Mirroring Sessions (Individual Network Taps) of Nitro based EC2 instances.
 Traffic Mirroring enables use of the network to audit the behavior of deployed EC2 instances, 
 by sending a copy of all traffic to a network security product like Vectra Cognito Detect.
 
@@ -17,7 +17,7 @@ The tool can selectively tap any VPCs in one AWS account, as well as tap each EN
 
 Enrollment Mode: This setting is configured at the VPC level using the vpc_config tool. The default mode is Auto.
 
-- Auto Enrollment: All discovered running instances will be tapped, except for those which are blacklisted.
+- Auto Enrollment (with blacklisting): All discovered running instances will be tapped, except for those which are blacklisted.
 - Whitelist Enrollment: No instances are tapped, except those which are whitelisted. (Blacklist does not apply). 
 
 
@@ -26,7 +26,7 @@ AWS VPC Traffic Mirroring Architecture
 ![TrafficMirror Architecture!](docs/AWS_SessionMirror_Architecture.png)
 
 
-This configuration scripts (session_mirror_blacklist, session_mirror_whitelist, session_mirror_config_vpc) do the following:
+These configuration scripts (session_mirror_blacklist, session_mirror_whitelist, session_mirror_config_vpc) do the following:
 
 1. For each VPC that should be monitored, denote a Traffic Mirroring Target and an instance Enrollment Mode by applying AWS Tags to the VPC 
 1. [Optional] Create an AWS NLB (network load balancer) to be the target of Mirroring Sessions 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,43 @@
-# AWS Session Mirroring Tool
+# AWS VPC Traffic Mirroring Session Manager
 
-This tool automates the creation and maintenance AWS Session Mirrors (Network Taps) of Nitro based EC2 instances. 
-Session Mirroring enables using the network to audit the behavior of deployed EC2 instances, by sending the traffic to network security products like Vectra Cognito Detect.
+This tool automates the creation and maintenance VPC Traffic Mirroring Sessions (Individual Network Taps) of Nitro based EC2 instances. 
+Traffic Mirroring enables use of the network to audit the behavior of deployed EC2 instances, 
+by sending a copy of all traffic to a network security product like Vectra Cognito Detect.
 
 | Notice: Usage of this tool can lead to significant AWS charges from the network taps created or the NLB data transfer charges. No warranty or recourse are provided. |
 | --- |
 
 What this tool solves:
 
-- Automating the creation and removal of Session Mirrors on EC2 instances.
-- 'healing' the intended state of Session Mirrors after EC2 instances are created or destroyed, when this tool is triggered or scheduled to automatically run.
+- Automating the creation and removal of Traffic Mirroring Sessions on EC2 instances.
+- 'healing' the intended state of Traffic Mirroring Sessions after EC2 instances are created or destroyed, when this tool is triggered or scheduled to automatically run.
 
+## Capabilities
 The tool can selectively tap any VPCs in one AWS account, as well as tap each ENI (Elastic Network Interface) attached to an EC2.
 
+Enrollment Mode: This setting is configured at the VPC level using the vpc_config tool. The default mode is Auto.
+
+- Auto Enrollment: All discovered running instances will be tapped, except for those which are blacklisted.
+- Whitelist Enrollment: No instances are tapped, except those which are whitelisted. (Blacklist does not apply). 
 
 
-AWS Session Mirroring Architecture
-![SessionMirror Architecture!](docs/AWS_SessionMirror_Architecture.png)
+
+AWS VPC Traffic Mirroring Architecture
+![TrafficMirror Architecture!](docs/AWS_SessionMirror_Architecture.png)
 
 
-This configuration scripts (session_mirror_blacklist, session_mirror_config_vpc) do the following:
+This configuration scripts (session_mirror_blacklist, session_mirror_whitelist, session_mirror_config_vpc) do the following:
 
-1. For each VPC that should be monitored, denote a Traffic Mirroring Target by applying AWS Tags to the VPC
-1. [Optional] Create an AWS NLB (network load balancer) to be the target of Session Mirroring Traffic 
-1. For each EC2 that should be blacklisted from Session Mirroring, denote that by applying AWS Tags to the EC2 instance
+1. For each VPC that should be monitored, denote a Traffic Mirroring Target and an instance Enrollment Mode by applying AWS Tags to the VPC 
+1. [Optional] Create an AWS NLB (network load balancer) to be the target of Mirroring Sessions 
+1. For each EC2 that should be blacklisted from having a Mirroring Session, denote that by applying AWS Tags to the EC2 instance
+1. [Optional] When using whitelist Enrollment Mode, denote instances that should participate by applying AWS Tags to the EC2 instace
 
 The runtime script (session_mirror_tap) does the following:
 
-1. Create Session Mirroring Filters suitable for use with Vectra Cognito Detect (copy all possible traffic including DNS)
+1. Create Traffic Mirroring Filters suitable for use with Vectra Cognito Detect (copy all possible traffic including DNS)
 1. Discover all eligible instances (currently only Nitro based instances are supported) in each VPC, and their respective ENI's 
-1. Create or remove Traffic Mirroring Sessions on each ENI using Filters
+1. Create or remove Mirroring Sessions on each ENI according to VPC Configuration, blacklist, whitelists, and AWS instance state.
 
 
 ![Network Tapping Tool!](docs/AWS_Network_Tap.png)
@@ -56,8 +64,24 @@ git clone git@github.com:vectranetworks/AWS-Session-Mirroring-Tool.git
 python setup.py install
 ```
 
-### Configuring an AWS Account for Session Mirroring
-Before Session Mirroring can take place, each VPC must have a Session Mirroring Target configured. 
+### Updating to a new version of Traffic Mirroring Session Manager
+
+1. Update the repo (or reclone)
+```console
+git pull
+```
+1. Rebuild
+```console
+python setup.py build
+```
+1. Reinstall
+```console
+python setup.py install
+```
+
+
+### Configuring an AWS Account for Traffic Mirroring
+Before Traffic Mirroring can take place, each VPC must have a Mirror Target configured. 
 Any instances that should not participate (Vectra Sensor/Brain) should then be blacklisted.
 This is done by applying tags inside the AWS Account.
 
@@ -66,15 +90,15 @@ This is done by applying tags inside the AWS Account.
 session_mirror_blacklist (Interactive)
 ```
 
-2. Configure the VPCs which should participate in Session Mirroring:
+2. Configure the VPCs which should participate in Traffic Mirroring:
 ```console
 session_mirror_config_vpc (Interactive)
 ```
     
-### Install the Session Mirrors (Network Taps)
+### Create the Traffic Mirror Sessions (Network Taps)
 After configuration is complete or updated, the 'session_mirror_tap' command should be run, as well as any time an EC2 is launched or removed in the account.
-This step performs the creation of the Session Mirroring instances, which will start sending traffic to the Session Mirroring Target.
-If there isn't routable connectivity between the instance and the target, no traffic will arrive at the target.
+This step performs the creation of the Traffic Mirroring Sessions, which will start sending traffic to the Mirror Target.
+If there isn't routable connectivity between the Mirror Session and the Mirror Target, no traffic will arrive at the target.
 ```console
 session_mirror_tap (Unattended)
 ```

--- a/aws_network_tap/blacklist.py
+++ b/aws_network_tap/blacklist.py
@@ -5,6 +5,7 @@ Sensors and Brains should not be tapped.
 
 import logging
 from aws_network_tap.models.ec2_api_client import Ec2ApiClient
+from aws_network_tap.models.tag_config import EC2Config
 
 
 def set_blacklist(region: str, enabled: bool = True) -> None:
@@ -24,7 +25,7 @@ def main() -> None:
     logging.getLogger().setLevel(logging.INFO)
     region = Ec2ApiClient.get_region()
     set_blacklist(region=region, enabled=True)
-    blacklist = Ec2ApiClient.get_blacklist(region=region)
+    blacklist = Ec2ApiClient.get_instances_by_tag(region=region, tag=EC2Config.T_BLACKLIST)
     print(f"Current Blacklist: {blacklist}")
     set_blacklist(region=region, enabled=False)
 

--- a/aws_network_tap/config_vpc.py
+++ b/aws_network_tap/config_vpc.py
@@ -8,7 +8,7 @@ from typing import Union
 from aws_network_tap.models.ec2_api_client import Ec2ApiClient, VPC_Props, Mirror_Target_Props
 from aws_network_tap.models.nlb_factory import NlbFactory
 from aws_network_tap.models.nlb_target_factory import NlbTargetFactory
-from aws_network_tap.models.aws_tag import AWSTag
+from aws_network_tap.models.tag_config import VPCTagConfig
 
 
 def find_target(region: str, vpc_id: str) -> str:
@@ -22,39 +22,52 @@ def find_target(region: str, vpc_id: str) -> str:
 
 def find_mirror_target(region: str, vpc_id: str) -> Union[str, None]:
     """ return mirror target ARN """
-    print("Choose a Mirror Target. Note: IP traffic must be routeable from the source ENI to the target.")
+    print("Choose a Mirror Target. Note: IP traffic must be routable from the source ENI to the target.")
 
     for target in Ec2ApiClient.list_mirror_targets(region=region):  # type: Mirror_Target_Props
         if target.vpc_bound and target.vpc_id != vpc_id:
             print(f'Warning: [{target.name}] is not recommended, unless transit gateway or vpc peering is in place.')
 
-        if 'y' in (input(f'Use existing Session Mirror Target [{target.name}] {target.target_id}? (n) ').lower() or 'n'):
+        if 'y' in (input(f'Use existing Traffic Mirror Target [{target.name}] {target.target_id}? (n) ').lower() or 'n'):
             return target.target_id
 
-    make_nlb_target = 'y' in input("Create new Session Mirroring Target? (n) ").lower()
+    make_nlb_target = 'y' in input("Create new Traffic Mirroring Target? (n) ").lower()
     if not make_nlb_target:
         raise ValueError('A Mirror Target is required to continue')
     target_arn = find_target(region=region, vpc_id=vpc_id)
     d_target_id = NlbTargetFactory(region=region, vpc_ids=[vpc_id]).find_or_create(
         nlb_or_eni_arn=target_arn
     )
-    logging.info(f"Created Session Mirroring Target {d_target_id}")
+    logging.info(f"Created Traffic Mirroring Target {d_target_id}")
     return d_target_id
 
 
-def prompt_vpc_config(vpc_prop: VPC_Props, region: str):
-    # if it currently has a certain tag, its tapped
-    current_tap_state = bool(vpc_prop.tags.get(Ec2ApiClient.TAG_KEY_VPC_TAP))
-    desc = 'enabled to ' + vpc_prop.tags.get(Ec2ApiClient.TAG_KEY_VPC_TAP) if current_tap_state else 'disabled'
-    change_config = 'y' in input(f'Modify default Session Mirroring Target for {vpc_prop.vpc_id}:{vpc_prop.name} (currently {desc})? (n) ').lower()
+def prompt_vpc_config(vpc_prop: VPC_Props, region: str) -> None:
+    """
+    The VPC configuration is stored in the account using tags, per the properties supported in VPCTagConfig
+    """
+    current_config = VPCTagConfig(vpc_prop.tags)
+    desc = 'enabled to `{}` with enrollment mode `{}`'.format(current_config.target, current_config.enrollment) if current_config.enabled else 'disabled'
+    change_config = 'y' in input(f'Modify VPC config for {vpc_prop.vpc_id}:{vpc_prop.name} (currently {desc})? (n) ').lower()
     if not change_config:
         return
-    if current_tap_state and 'y' in input(f"Disable Session Mirroring for this VPC? (n) ").lower():
-        mirror_target_arn = AWSTag.Delete
+    if current_config.enabled and 'y' in input(f"Disable Traffic Mirroring for this VPC? (n) ").lower():
+        mirror_target_arn = None
     else:
         mirror_target_arn = find_mirror_target(region=region, vpc_id=vpc_prop.vpc_id)
-    Ec2ApiClient.set_vpc_target(region=region, vpc_id=vpc_prop.vpc_id, session_mirror_target_arn=mirror_target_arn)
-    logging.info(f'VPC Session Mirroring Target updated to {mirror_target_arn}')
+    new_config = VPCTagConfig(vpc_prop.tags)
+    new_config.target = mirror_target_arn
+    auto_mode_default = 'y' if current_config.auto_enrollment else ''
+    resp = input(
+        f"Enrollment Mode: "
+        f"Y for {VPCTagConfig.V_ENROLLMENT_AUTO} mode, "
+        f"N for {VPCTagConfig.V_ENROLLMENT_WHITELIST} mode. "
+        f"(Currently {current_config.enrollment}) "
+        f"Mirror all instances by default? ({auto_mode_default}) ").lower() or auto_mode_default
+    auto_mode = 'y' in resp
+    new_config.enrollment = VPCTagConfig.V_ENROLLMENT_AUTO if auto_mode else VPCTagConfig.V_ENROLLMENT_WHITELIST
+    Ec2ApiClient.set_vpc_config(region=region, vpc_id=vpc_prop.vpc_id, config=new_config)
+    logging.info(f'VPC Traffic Mirroring Target updated to {mirror_target_arn} in {new_config.enrollment} Enrollment Mode')
 
 
 def main() -> None:

--- a/aws_network_tap/config_vpc.py
+++ b/aws_network_tap/config_vpc.py
@@ -47,7 +47,7 @@ def prompt_vpc_config(vpc_prop: VPC_Props, region: str) -> None:
     The VPC configuration is stored in the account using tags, per the properties supported in VPCTagConfig
     """
     current_config = VPCTagConfig(vpc_prop.tags)
-    desc = 'enabled to `{}` with enrollment mode `{}`'.format(current_config.target, current_config.enrollment) if current_config.enabled else 'disabled'
+    desc = f'enabled to `{current_config.target}` with enrollment mode `{current_config.enrollment}`' if current_config.enabled else 'disabled'
     change_config = 'y' in input(f'Modify VPC config for {vpc_prop.vpc_id}:{vpc_prop.name} (currently {desc})? (n) ').lower()
     if not change_config:
         return

--- a/aws_network_tap/constants.py
+++ b/aws_network_tap/constants.py
@@ -1,0 +1,2 @@
+
+VENDOR = "Vectra"

--- a/aws_network_tap/models/spile_tapper.py
+++ b/aws_network_tap/models/spile_tapper.py
@@ -176,7 +176,8 @@ class SpileTapper(Ec2ApiClient):
         tapper = SpileTapper(region=region, vpc_ids=vpc_ids)
         if not config.enabled:
             return
-        ec2_blacklist = ec2_whitelist = []
+        ec2_blacklist = []
+        ec2_whitelist = []
         if config.auto_enrollment:
             ec2_blacklist = Ec2ApiClient.get_instances_by_tag(region=region, tag=EC2Config.T_BLACKLIST)
         else:

--- a/aws_network_tap/models/spile_tapper.py
+++ b/aws_network_tap/models/spile_tapper.py
@@ -3,6 +3,7 @@ from typing import Generator, List
 from aws_network_tap.models.ec2_api_client import Ec2ApiClient, ENI_Tag
 from aws_network_tap.models.spile import Spile
 from aws_network_tap.models.aws_tag import AWSTag
+from aws_network_tap.models.tag_config import EC2Config, VPCTagConfig
 
 
 class SpileTapper(Ec2ApiClient):
@@ -171,13 +172,18 @@ class SpileTapper(Ec2ApiClient):
                         )
 
     @classmethod
-    def manage(cls, region: str, vpc_ids: List[str], target_id: str, blacklist: List[str] = None) -> None:
+    def manage(cls, region: str, vpc_ids: List[str], config: VPCTagConfig) -> None:
         tapper = SpileTapper(region=region, vpc_ids=vpc_ids)
-        ec2_blacklist = Ec2ApiClient.get_blacklist(region=region)
+        if not config.enabled:
+            return
+        ec2_blacklist = ec2_whitelist = []
+        if config.auto_enrollment:
+            ec2_blacklist = Ec2ApiClient.get_instances_by_tag(region=region, tag=EC2Config.T_BLACKLIST)
+        else:
+            ec2_whitelist = Ec2ApiClient.get_instances_by_tag(region=region, tag=EC2Config.T_WHITELIST)
         for spile in tapper.discover():  # type: Spile
-            do_tap = bool(target_id)
-            if blacklist and spile.eni_tag.instance_id in blacklist:
-                do_tap = False
-            if spile.eni_tag.instance_id in ec2_blacklist:
-                do_tap = False
-            spile.manage(target_id=target_id, do_tap=do_tap)
+            if config.auto_enrollment:
+                do_tap = spile.eni_tag.instance_id not in ec2_blacklist
+            else:
+                do_tap = spile.eni_tag.instance_id in ec2_whitelist
+            spile.manage(target_id=config.target, do_tap=do_tap)

--- a/aws_network_tap/models/tag_config.py
+++ b/aws_network_tap/models/tag_config.py
@@ -1,0 +1,107 @@
+"""
+These are models to hold business logic when using AWS Tags for persisted state,
+and to assist serializing back to AWS's tag format after transformations.
+"""
+
+from typing import Union, List
+
+from aws_network_tap.models.aws_tag import AWSTag
+from aws_network_tap.constants import VENDOR
+
+
+class TagConfig:
+    """
+    This is the abstract class. There are no tags keys defined, so it cannot hold any values.
+    """
+    TAGS = []  # override this list in each class with the keys used for a particular asset type
+
+    def __init__(self, tags: dict = None) -> None:
+        self.tags = tags if tags else {}
+
+    def get_aws_tags(self) -> List[dict]:
+        """
+        return only the tags that are defined as part of a model config, and have been explicitly set, in AWS tag format
+        """
+        return AWSTag.to_tags({i: self.tags[i] for i in self.tags if i in self.TAGS})
+
+
+class VPCTagConfig(TagConfig):
+    """
+    Holds VPC Level Configuration
+    """
+    T_TARGET = VENDOR + ':session_mirroring_target'  # arn
+    T_ENROLLMENT = VENDOR + ':session_mirroring_enrollment'  # enum (Auto)
+
+    TAGS = [
+        T_TARGET,
+        T_ENROLLMENT,
+    ]
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.target)
+
+    @property
+    def target(self) -> Union[str, None]:
+        return self.tags[self.T_TARGET] if self.tags.get(self.T_TARGET) else None
+
+    @target.setter
+    def target(self, value: Union[str, None]) -> None:
+        self.tags[self.T_TARGET] = value if value else AWSTag.Delete
+
+    V_ENROLLMENT_AUTO = 'auto'
+    V_ENROLLMENT_WHITELIST = 'whitelist'
+
+    @property
+    def enrollment(self) -> str:
+        return self.tags.get(self.T_ENROLLMENT, self.V_ENROLLMENT_AUTO)
+
+    @enrollment.setter
+    def enrollment(self, value) -> None:
+        if value not in [self.V_ENROLLMENT_AUTO, self.V_ENROLLMENT_WHITELIST, AWSTag.Delete]:
+            raise ValueError('illegal option')
+        self.tags[self.T_ENROLLMENT] = value
+
+    @property
+    def auto_enrollment(self) -> bool:
+        return self.enrollment == self.V_ENROLLMENT_AUTO
+
+
+class EC2Config(TagConfig):
+    """
+    Holds EC2 Level Configuration
+    """
+    T_BLACKLIST = VENDOR + ':session_mirroring_blacklist'
+    T_WHITELIST = VENDOR + ':session_mirroring_whitelist'
+
+    TAGS = [
+        T_BLACKLIST,
+        T_WHITELIST,
+    ]
+
+    V_TRUE = 'True'
+    V_FALSE = AWSTag.Delete
+
+    @property
+    def blacklist(self) -> Union[bool, None]:
+        if self.tags.get(self.T_BLACKLIST, 'shadow') == 'shadow':
+            return None
+        return self.tags.get(self.T_BLACKLIST) == self.V_TRUE
+
+    @blacklist.setter
+    def blacklist(self, value: bool) -> None:
+        if value and self.whitelist:
+            raise ValueError('cannot blacklist an instance which is whitelisted')
+        self.tags[self.T_BLACKLIST] = self.V_TRUE if value else self.V_FALSE
+
+    @property
+    def whitelist(self) -> Union[bool, None]:
+        if self.tags.get(self.T_WHITELIST, 'shadow') == 'shadow':
+            return None
+        return self.tags.get(self.T_WHITELIST) == self.V_TRUE
+
+    @whitelist.setter
+    def whitelist(self, value: bool) -> None:
+        if value and self.blacklist:
+            raise ValueError('cannot whitelist an instance which is blacklisted')
+        self.tags[self.T_WHITELIST] = self.V_TRUE if value else self.V_FALSE

--- a/aws_network_tap/tap.py
+++ b/aws_network_tap/tap.py
@@ -7,9 +7,9 @@ Specific instances can be opted out with the blacklist tool.
 
 """
 import logging
-from typing import List
 from aws_network_tap.models.ec2_api_client import Ec2ApiClient, VPC_Props
 from aws_network_tap.models.spile_tapper import SpileTapper
+from aws_network_tap.models.tag_config import VPCTagConfig
 
 
 def main() -> None:
@@ -17,12 +17,8 @@ def main() -> None:
     region = Ec2ApiClient.get_region()
     for vpc_prop in Ec2ApiClient.list_vpcs(region=region):  # type: VPC_Props
         logging.info(f" Managing Session Mirroring for VPC {vpc_prop.name}: {vpc_prop.vpc_id}")
-        try:
-            target_id = vpc_prop.tags[Ec2ApiClient.TAG_KEY_VPC_TAP]
-        except KeyError:
-            target_id = None
-        blacklist = []  # type: List[str]
-        SpileTapper.manage(region=region, vpc_ids=[vpc_prop.vpc_id], target_id=target_id, blacklist=blacklist)
+        config = VPCTagConfig(vpc_prop.tags)
+        SpileTapper.manage(region=region, vpc_ids=[vpc_prop.vpc_id], config=config)
 
 
 if __name__ == "__main__":

--- a/aws_network_tap/tests/models/test_tag_config.py
+++ b/aws_network_tap/tests/models/test_tag_config.py
@@ -1,0 +1,124 @@
+from unittest import TestCase
+from aws_network_tap.models.aws_tag import AWSTag
+from aws_network_tap.models.tag_config import VPCTagConfig, EC2Config, TagConfig
+import logging
+logging.getLogger().setLevel(logging.INFO)
+
+
+class TestTagConfig(TestCase):
+    def test_get_tags_empty(self):
+        c = TagConfig()
+        self.assertEqual([], c.get_aws_tags())
+
+    def test_tags_insert(self):
+        c = TagConfig()
+        c.TAGS.append('Foo')
+        self.assertEqual([], c.get_aws_tags())
+
+    def test_tag_is_set_after_init(self):
+        c = TagConfig()
+        c.TAGS.append('Foo')
+        c.tags['Foo'] = 'Bar'
+        self.assertEqual([{'Key': 'Foo', 'Value': 'Bar'}], c.get_aws_tags())
+
+    def test_tag_is_set_after_none_init(self):
+        c = TagConfig()
+        c.TAGS.append('Foo')
+        c.tags['Foo'] = AWSTag.Delete
+        self.assertEqual([{'Key': 'Foo'}], c.get_aws_tags())
+
+
+class TestVPCTags(TestCase):
+
+    def test_empty_config(self):
+        config = VPCTagConfig()
+        self.assertEqual([], config.get_aws_tags())
+
+    def test_none(self):
+        config = VPCTagConfig()
+        self.assertFalse(config.enabled)
+        self.assertIsNone(config.target)
+
+    def test_enable(self):
+        config = VPCTagConfig()
+        config.target = 'arn:foo/bar'
+        self.assertTrue(config.enabled)
+        self.assertEqual('arn:foo/bar', config.target)
+
+    def test_disable(self):
+        config = VPCTagConfig()
+        config.target = None
+        self.assertFalse(config.enabled)
+
+    def test_get_aws_tags(self):
+        config = VPCTagConfig()
+        config.target = 'arn:foo/bar'
+        self.assertEqual([{'Key': 'Vectra:session_mirroring_target', 'Value': 'arn:foo/bar'}], config.get_aws_tags())
+
+    def test_dump_garbage_tags(self):
+        config = VPCTagConfig({
+            VPCTagConfig.T_TARGET: 'arn:aws:foo/bar',
+            'flavor': 'development',
+        })
+        self.assertTrue(config.enabled)
+        self.assertEqual(1, len(config.get_aws_tags()), config.get_aws_tags())
+
+    def test_enrollment_value_error(self):
+        config = VPCTagConfig()
+        with self.assertRaises(ValueError) as e:
+            config.enrollment = 'cheese'
+
+    def test_enrollment_default(self):
+        config = VPCTagConfig()
+        self.assertEqual(config.V_ENROLLMENT_AUTO, config.enrollment)
+
+    def test_enrollment_set(self):
+        config = VPCTagConfig()
+        config.enrollment = config.V_ENROLLMENT_WHITELIST
+        self.assertEqual(config.V_ENROLLMENT_WHITELIST, config.enrollment)
+        config.target = 'arn:aws:foo/bar'
+        self.assertEqual(2, len(config.get_aws_tags()))
+        for tag in config.get_aws_tags():
+            self.assertEqual(2, len(tag))
+
+    def test_enrollment_set_none(self):
+        config = VPCTagConfig()
+        config.enrollment = None
+        config.target = None
+        self.assertEqual(2, len(config.get_aws_tags()))
+        for tag in config.get_aws_tags():
+            self.assertEqual(1, len(tag))
+
+
+class TestEc2Tags(TestCase):
+
+    def test_defaults(self):
+        config = EC2Config()
+        self.assertIsNone(config.blacklist)
+        self.assertIsNone(config.whitelist)
+        self.assertEqual([], config.get_aws_tags())
+
+    def test_set_blacklist(self):
+        config = EC2Config()
+        config.blacklist = True
+        self.assertTrue(config.blacklist)
+        self.assertEqual([{'Key': 'Vectra:session_mirroring_blacklist', 'Value': 'True'}], config.get_aws_tags())
+
+    def test_set_whitelist(self):
+        config = EC2Config()
+        config.whitelist = True
+        self.assertTrue(config.whitelist)
+        self.assertEqual([{'Key': 'Vectra:session_mirroring_whitelist', 'Value': 'True'}], config.get_aws_tags())
+
+    def test_unset_whitelist(self):
+        config = EC2Config()
+        config.whitelist = False
+        self.assertFalse(config.whitelist)
+        self.assertEqual([{'Key': 'Vectra:session_mirroring_whitelist'}], config.get_aws_tags())
+
+    def test_cannot_set_both_true(self):
+        config = EC2Config()
+        config.blacklist = True
+        with self.assertRaises(ValueError) as e:
+            config.whitelist = True
+

--- a/aws_network_tap/whitelist.py
+++ b/aws_network_tap/whitelist.py
@@ -1,0 +1,35 @@
+"""
+Whitelists instances to being tapped.
+Only used when VPC tapping mode is 'whitelist' instead of the default 'auto'
+Sensors and Brains should not be tapped.
+"""
+
+import logging
+from aws_network_tap.models.ec2_api_client import Ec2ApiClient
+from aws_network_tap.models.tag_config import EC2Config
+
+
+def set_whitelist(region: str, enabled: bool = True) -> None:
+    mode = 'ADD TO' if enabled else 'REMOVE FROM'
+    pasted_input = input(f"Enter instance_id (or comma separated list of instance_ids) {mode} whitelist: ")
+    if not pasted_input:
+        return
+    instance_ids = [x.strip() for x in pasted_input.split(',')]
+    if not instance_ids:
+        return
+    for instance_id in instance_ids:
+        Ec2ApiClient.whitelist_instance(region=region, instance_id=instance_id, enabled=enabled)
+    logging.info('Whitelist config updated')
+
+
+def main() -> None:
+    logging.getLogger().setLevel(logging.INFO)
+    region = Ec2ApiClient.get_region()
+    set_whitelist(region=region, enabled=True)
+    whitelist = Ec2ApiClient.get_instances_by_tag(region=region, tag=EC2Config.T_WHITELIST)
+    print(f"Current Whitelist: {whitelist}")
+    set_whitelist(region=region, enabled=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
             'session_mirror_tap = aws_network_tap.tap:main',
             'session_mirror_config_vpc = aws_network_tap.config_vpc:main',
             'session_mirror_blacklist = aws_network_tap.blacklist:main',
+            'session_mirror_whitelist = aws_network_tap.whitelist:main',
         ]
     },
     install_requires=REQUIRED,


### PR DESCRIPTION
Implements Whitelist Traffic Mirroring

Creates the VPC Tag / config variable "Enrollment Mode", which defaults to "auto" but also supports "whitelist".

Auto mode will tap all found ENI's in the VPC. This was the default / only mode before.

Whitelist mode will only tap ENIs that are tagged with the whitelist tag. Use the new whitelist tool (works the same as the existing blacklist tool) to tag instances that will participate.

