### PR TITLE
Set log level with environment variable

### DIFF
--- a/aws_network_tap/blacklist.py
+++ b/aws_network_tap/blacklist.py
@@ -4,6 +4,7 @@ Sensors and Brains should not be tapped.
 """
 
 import logging
+import os
 from aws_network_tap.models.ec2_api_client import Ec2ApiClient
 from aws_network_tap.models.tag_config import EC2Config
 
@@ -22,7 +23,8 @@ def set_blacklist(region: str, enabled: bool = True) -> None:
 
 
 def main() -> None:
-    logging.getLogger().setLevel(logging.INFO)
+    log_level = os.getenv('LOG_LEVEL', 'INFO')
+    logging.getLogger().setLevel(log_level)
     region = Ec2ApiClient.get_region()
     set_blacklist(region=region, enabled=True)
     blacklist = Ec2ApiClient.get_instances_by_tag(region=region, tag=EC2Config.T_BLACKLIST)

--- a/aws_network_tap/config_vpc.py
+++ b/aws_network_tap/config_vpc.py
@@ -4,6 +4,7 @@ No actual instance tapping happens until spile_driver is called
 """
 
 import logging
+import os
 from typing import Union
 from aws_network_tap.models.ec2_api_client import Ec2ApiClient, VPC_Props, Mirror_Target_Props
 from aws_network_tap.models.nlb_factory import NlbFactory
@@ -71,7 +72,8 @@ def prompt_vpc_config(vpc_prop: VPC_Props, region: str) -> None:
 
 
 def main() -> None:
-    logging.getLogger().setLevel(logging.INFO)
+    log_level = os.getenv('LOG_LEVEL', 'INFO')
+    logging.getLogger().setLevel(log_level)
     region = Ec2ApiClient.get_region()
     for vpc_prop in Ec2ApiClient.list_vpcs(region=region):  # type: VPC_Props
         prompt_vpc_config(vpc_prop, region)

--- a/aws_network_tap/tap.py
+++ b/aws_network_tap/tap.py
@@ -7,13 +7,15 @@ Specific instances can be opted out with the blacklist tool.
 
 """
 import logging
+import os
 from aws_network_tap.models.ec2_api_client import Ec2ApiClient, VPC_Props
 from aws_network_tap.models.spile_tapper import SpileTapper
 from aws_network_tap.models.tag_config import VPCTagConfig
 
 
 def main() -> None:
-    logging.getLogger().setLevel(logging.INFO)
+    log_level = os.getenv('LOG_LEVEL', 'INFO')
+    logging.getLogger().setLevel(log_level)
     region = Ec2ApiClient.get_region()
     for vpc_prop in Ec2ApiClient.list_vpcs(region=region):  # type: VPC_Props
         logging.info(f" Managing Session Mirroring for VPC {vpc_prop.name}: {vpc_prop.vpc_id}")

--- a/aws_network_tap/tests/models/test_tag_config.py
+++ b/aws_network_tap/tests/models/test_tag_config.py
@@ -2,7 +2,10 @@ from unittest import TestCase
 from aws_network_tap.models.aws_tag import AWSTag
 from aws_network_tap.models.tag_config import VPCTagConfig, EC2Config, TagConfig
 import logging
-logging.getLogger().setLevel(logging.INFO)
+import os
+
+log_level = os.getenv('LOG_LEVEL', 'INFO')
+logging.getLogger().setLevel(log_level)
 
 
 class TestTagConfig(TestCase):

--- a/aws_network_tap/whitelist.py
+++ b/aws_network_tap/whitelist.py
@@ -5,6 +5,7 @@ Sensors and Brains should not be tapped.
 """
 
 import logging
+import os
 from aws_network_tap.models.ec2_api_client import Ec2ApiClient
 from aws_network_tap.models.tag_config import EC2Config
 
@@ -23,7 +24,8 @@ def set_whitelist(region: str, enabled: bool = True) -> None:
 
 
 def main() -> None:
-    logging.getLogger().setLevel(logging.INFO)
+    log_level = os.getenv('LOG_LEVEL', 'INFO')
+    logging.getLogger().setLevel(log_level)
     region = Ec2ApiClient.get_region()
     set_whitelist(region=region, enabled=True)
     whitelist = Ec2ApiClient.get_instances_by_tag(region=region, tag=EC2Config.T_WHITELIST)


### PR DESCRIPTION
This pull request will add the ability to set the log level using an environment variable.

Use the LOG_LEVEL environment variable to set the log level. If the environment variable does not exist, default to INFO.